### PR TITLE
[#10] [API] As a user, I can upload a CSV File and have its content saved

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -3,7 +3,15 @@
 module Api
   module V1
     class ApplicationController < ActionController::API
+      include ErrorHandlerConcern
+
       before_action :doorkeeper_authorize!
+
+      private
+
+      def current_user
+        @current_user ||= User.find_by(id: doorkeeper_token[:resource_owner_id])
+      end
     end
   end
 end

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class ApplicationController < ActionController::API
-      include ErrorHandlerConcern
+      include ErrorRenderable
 
       before_action :doorkeeper_authorize!
 

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -3,13 +3,35 @@
 module Api
   module V1
     class KeywordsController < ApplicationController
-      skip_before_action :doorkeeper_authorize!
-
       def index
         first_keyword = Keyword.new({ id: 1, name: 'First keyword' })
         second_keyword = Keyword.new({ id: 2, name: 'Second keyword' })
 
         render json: KeywordSerializer.new([first_keyword, second_keyword]).serializable_hash.to_json
+      end
+
+      def create
+        if csv_form.save(params[:file])
+          render json: create_success_response
+        else
+          render_errors(
+            details: csv_form.errors.full_messages,
+            code: :invalid_file,
+            status: :unprocessable_entity
+          )
+        end
+      end
+
+      private
+
+      def csv_form
+        @csv_form ||= CsvUploadForm.new(current_user)
+      end
+
+      def create_success_response
+        {
+          meta: I18n.t('csv.upload_success')
+        }
       end
     end
   end

--- a/app/controllers/concerns/api/v1/error_handler_concern.rb
+++ b/app/controllers/concerns/api/v1/error_handler_concern.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module ErrorHandlerConcern
+      extend ActiveSupport::Concern
+
+      private
+
+      def render_error(detail, source: nil, status: :unprocessable_entity)
+        error = build_error(detail: detail, source: source)
+        render_errors [error], status
+      end
+
+      def render_errors(jsonapi_errors, status = :unprocessable_entity)
+        render json: { errors: jsonapi_errors }, status: status
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/api/v1/error_renderable.rb
+++ b/app/controllers/concerns/api/v1/error_renderable.rb
@@ -2,9 +2,7 @@
 
 module Api
   module V1
-    module ErrorHandlerConcern
-      extend ActiveSupport::Concern
-
+    module ErrorRenderable
       private
 
       def render_error(detail, source: nil, status: :unprocessable_entity)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,7 @@
 en:
   hello: "Hello world"
   csv:
-    upload_success: 'Your file has been uploaded!'
+    upload_success: 'Your file has been uploaded successfuly!'
     validation:
       wrong_count: 'The csv file should contain between 1 and 1000 keywords'
       wrong_type: 'Please ensure the provided file type is csv'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@
 en:
   hello: "Hello world"
   csv:
+    upload_success: 'Your file has been uploaded!'
     validation:
       wrong_count: 'The csv file should contain between 1 and 1000 keywords'
       wrong_type: 'Please ensure the provided file type is csv'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,5 +34,5 @@ en:
   csv:
     upload_success: 'Your file has been uploaded successfuly!'
     validation:
-      wrong_count: 'The csv file should contain between 1 and 1000 keywords'
-      wrong_type: 'Please ensure the provided file type is csv'
+      wrong_count: 'The CSV file should contain between 1 and 1000 keywords'
+      wrong_type: 'Please ensure the provided file type is CSV'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
         controllers tokens: 'tokens'
         skip_controllers :authorizations, :applications, :authorized_applications, :token_info, :tokens, :confirmations
       end
-      resources :keywords, only: :index
+      resources :keywords, only: [:index, :create]
       resources :private_items, only: :index
       resources :tokens, only: [:create]
       resources :registrations, only: [:create]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2023_06_13_043615) do
     t.datetime "confirmed_at", precision: 6
     t.datetime "confirmation_sent_at", precision: 6
     t.string "unconfirmed_email"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/forms/csv_upload_form_spec.rb
+++ b/spec/forms/csv_upload_form_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe CsvUploadForm, type: :form do
       end
     end
 
-    context 'given a non csv file' do
-      it 'returns a wrong_type error' do
+    context 'given a none CSV file' do
+      it 'returns the wrong_type error' do
         user = Fabricate(:user)
         form = described_class.new(user)
         form.save(file_fixture('csv/wrong_type.txt'))

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -3,17 +3,13 @@
 RSpec.describe Api::V1::KeywordsController, type: :request do
   describe 'GET#index' do
     it 'returns success status' do
-      header, = create_token_header
-
-      get api_v1_keywords_path, headers: header
+      get api_v1_keywords_path, headers: create_token_header
 
       expect(response).to have_http_status(:success)
     end
 
     it 'returns the valid keywords' do
-      header, = create_token_header
-
-      get api_v1_keywords_path, headers: header
+      get api_v1_keywords_path, headers: create_token_header
 
       keywords = JSON.parse(response.body, symbolize_names: true)[:data]
 
@@ -23,61 +19,54 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
   end
 
   describe 'POST#index' do
-    context 'when csv file is valid' do
+    context 'when CSV file is valid' do
       it 'returns success status' do
-        header, = create_token_header
         params = { 'file' => fixture_file_upload('csv/valid.csv') }
-        post api_v1_keywords_path, params: params, headers: header
+        post api_v1_keywords_path, params: params, headers: create_token_header
 
         expect(response).to have_http_status(:success)
       end
 
       it 'saves 10 keywords to the DB' do
-        header, = create_token_header
         params = { 'file' => fixture_file_upload('csv/valid.csv') }
-        post api_v1_keywords_path, params: params, headers: header
+        post api_v1_keywords_path, params: params, headers: create_token_header
 
-        expect { post api_v1_keywords_path, params: params, headers: header }.to change(Keyword, :count).by(10)
+        expect { post api_v1_keywords_path, params: params, headers: create_token_header }.to change(Keyword, :count).by(10)
       end
 
       it 'returns the upload_success meta message' do
-        header, = create_token_header
         params = { 'file' => fixture_file_upload('csv/valid.csv') }
-        post api_v1_keywords_path, params: params, headers: header
+        post api_v1_keywords_path, params: params, headers: create_token_header
 
         expect(JSON.parse(response.body)['meta']).to eq(I18n.t('csv.upload_success'))
       end
     end
 
-    context 'when csv file is missing' do
+    context 'when CSV file is missing' do
       it 'returns unprocessable_entity status' do
-        header, = create_token_header
-        post api_v1_keywords_path, headers: header
+        post api_v1_keywords_path, headers: create_token_header
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
       it 'returns a invalid_file error' do
-        header, = create_token_header
-        post api_v1_keywords_path, headers: header
+        post api_v1_keywords_path, headers: create_token_header
 
         expect(JSON.parse(response.body)['errors']['code']).to eq('invalid_file')
       end
     end
 
-    context 'when csv file is in the wrong type' do
+    context 'when CSV file is in the wrong type' do
       it 'returns unprocessable_entity status' do
-        header, = create_token_header
         params = { 'file' => fixture_file_upload('csv/wrong_type.txt') }
-        post api_v1_keywords_path, params: params, headers: header
+        post api_v1_keywords_path, params: params, headers: create_token_header
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
-      it 'returns a wrong_type error' do
-        header, = create_token_header
+      it 'returns the wrong_type error' do
         params = { 'file' => fixture_file_upload('csv/wrong_type.txt') }
-        post api_v1_keywords_path, params: params, headers: header
+        post api_v1_keywords_path, params: params, headers: create_token_header
 
         expect(JSON.parse(response.body)['errors']['details']).to include(I18n.t('csv.validation.wrong_type'))
       end

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -56,6 +56,13 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
+
+      it 'returns a invalid_file error' do
+        header, = create_token_header
+        post api_v1_keywords_path, headers: header
+
+        expect(JSON.parse(response.body)['errors']['code']).to eq('invalid_file')
+      end
     end
 
     context 'when csv file is in the wrong type' do
@@ -65,6 +72,14 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
         post api_v1_keywords_path, params: params, headers: header
 
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns a wrong_type error' do
+        header, = create_token_header
+        params = { 'file' => fixture_file_upload('csv/wrong_type.txt') }
+        post api_v1_keywords_path, params: params, headers: header
+
+        expect(JSON.parse(response.body)['errors']['details']).to include(I18n.t('csv.validation.wrong_type'))
       end
     end
 

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -3,18 +3,78 @@
 RSpec.describe Api::V1::KeywordsController, type: :request do
   describe 'GET#index' do
     it 'returns success status' do
-      get api_v1_keywords_path
+      header, = create_token_header
+
+      get api_v1_keywords_path, headers: header
 
       expect(response).to have_http_status(:success)
     end
 
     it 'returns the valid keywords' do
-      get api_v1_keywords_path
+      header, = create_token_header
+
+      get api_v1_keywords_path, headers: header
 
       keywords = JSON.parse(response.body, symbolize_names: true)[:data]
 
       expect(keywords[0][:attributes][:name]).to eq('First keyword')
       expect(keywords[1][:attributes][:name]).to eq('Second keyword')
+    end
+  end
+
+  describe 'POST#index' do
+    context 'when csv file is valid' do
+      it 'returns success status' do
+        header, = create_token_header
+        params = { 'file' => fixture_file_upload('csv/valid.csv') }
+        post api_v1_keywords_path, params: params, headers: header
+
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'saves 10 keywords to the DB' do
+        header, = create_token_header
+        params = { 'file' => fixture_file_upload('csv/valid.csv') }
+        post api_v1_keywords_path, params: params, headers: header
+
+        expect { post api_v1_keywords_path, params: params, headers: header }.to change(Keyword, :count).by(10)
+      end
+
+      it 'returns the upload_success meta message' do
+        header, = create_token_header
+        params = { 'file' => fixture_file_upload('csv/valid.csv') }
+        post api_v1_keywords_path, params: params, headers: header
+
+        expect(JSON.parse(response.body)['meta']).to eq(I18n.t('csv.upload_success'))
+      end
+    end
+
+    context 'when csv file is missing' do
+      it 'returns unprocessable_entity status' do
+        header, = create_token_header
+        post api_v1_keywords_path, headers: header
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'when csv file is in the wrong type' do
+      it 'returns unprocessable_entity status' do
+        header, = create_token_header
+        params = { 'file' => fixture_file_upload('csv/wrong_type.txt') }
+        post api_v1_keywords_path, params: params, headers: header
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'when user is not signed in' do
+      it 'returns unauthorized status' do
+        params = { 'file' => fixture_file_upload('csv/valid.csv') }
+        post api_v1_keywords_path, params: params
+
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 end

--- a/spec/support/oauth_helpers.rb
+++ b/spec/support/oauth_helpers.rb
@@ -42,6 +42,6 @@ module OAuthHelpers
     application = Fabricate(:application)
     access_token = Fabricate(:access_token, resource_owner_id: user.id, application_id: application.id)
 
-    [{ 'Authorization' => "Bearer #{access_token.token}" }, user]
+    { 'Authorization' => "Bearer #{access_token.token}" }
   end
 end


### PR DESCRIPTION
- close #10

## What happened 👀

Create **authenticated** endpoint `POST` `/api/v1/keyword`
    - Input:
        - Files: `CSV`
        - `Authentication` Header: `Bearer {Token}`
    - Returns `200` and empty JSON `{meta: message}` if success.
    - Returns error `400` if CSV is missing, non-CSV was uploaded, or CSV is in the wrong format.
    
## Insight 📝

- Add `create_token_header` to `o_auth_helper`.
- Add `ErrorHandlerConcern` for quick error render for API.
- `keywords_controller` `#post` uses existing `csv_form`.

## Proof Of Work 📹

<img width="458" alt="Screen Shot 2023-06-19 at 11 28 4
<img width="1392" alt="Screen Shot 2023-06-19 at 11 27 06" src="https://github.com/nimblehq/ic-rails-phong-bliss/assets/6356137/545587f2-c683-40df-b260-e33d9d0bacae">
6" src="https://github.com/nimblehq/ic-rails-phong-bliss/assets/6356137/b46db5c2-224e-4561-b229-3597658ad69e">

