### PR TITLE
[#46] Fix: Heroku crashes because `simplecov`

### DIFF
--- a/config/initializers/simplecov.rb
+++ b/config/initializers/simplecov.rb
@@ -1,20 +1,22 @@
 # frozen_string_literal: true
 
-require 'simplecov'
-require 'simplecov-json'
-require 'simplecov-lcov'
+if ENV['RAILS_ENV'] == 'test' 
+  require 'simplecov'
+  require 'simplecov-json'
+  require 'simplecov-lcov'
 
-formatters = [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::JSONFormatter, SimpleCov::Formatter::LcovFormatter]
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(formatters)
+  formatters = [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::JSONFormatter, SimpleCov::Formatter::LcovFormatter]
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(formatters)
 
-if ENV['CIRCLE_ARTIFACTS']
-  dir = File.join('..', '..', '..', ENV['CIRCLE_ARTIFACTS'], 'coverage')
-  SimpleCov.coverage_dir(dir)
-end
+  if ENV['CIRCLE_ARTIFACTS']
+    dir = File.join('..', '..', '..', ENV['CIRCLE_ARTIFACTS'], 'coverage')
+    SimpleCov.coverage_dir(dir)
+  end
 
-SimpleCov.start 'rails' do
-  add_filter '/vendor/'
-  add_filter '/config/'
-  add_filter '/spec/'
-  add_filter '/db/'
+  SimpleCov.start 'rails' do
+    add_filter '/vendor/'
+    add_filter '/config/'
+    add_filter '/spec/'
+    add_filter '/db/'
+  end
 end


### PR DESCRIPTION
- close #46

## What happened 👀

Fix `simplecov` crashing deployment.

## Insight 📝

- To allow `simplecov` to run when start we added it to `initializers` but this causes issue because it is being invoke but missing for `production` env.
- Add `test` env check for simplecov.
- Test and coverage should run correctly.

## Proof Of Work 📹

Calling api now returns correct error when signed in.

<img width="1392" alt="Screen Shot 2023-06-15 at 18 51 19" src="https://github.com/nimblehq/ic-rails-phong-bliss/assets/6356137/d2204cc5-e211-427d-ae9e-a269cc4f7199">
<img width="1392" alt="Screen Shot 2023-06-15 at 18 51 21" src="https://github.com/nimblehq/ic-rails-phong-bliss/assets/6356137/05b5f685-4746-4b1c-a9d8-bbd19345e225">
