### PR TITLE
[#40] [Backend] As a user, I can verify my account with the link in my account verification email

### DIFF
--- a/app/controllers/api/v1/confirmations_controller.rb
+++ b/app/controllers/api/v1/confirmations_controller.rb
@@ -2,6 +2,10 @@
 
 module Api
   module V1
-    class ConfirmationsController < Devise::ConfirmationsController; end
+    class ConfirmationsController < Devise::ConfirmationsController
+      def after_confirmation_path_for(_resource_name, _resource)
+        success_messages_path
+      end
+    end
   end
 end

--- a/app/controllers/private_items_controller.rb
+++ b/app/controllers/private_items_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PrivateItemsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :doorkeeper_authorize!
 
   def index
     render json: 'Welcome back'

--- a/app/controllers/success_messages_controller.rb
+++ b/app/controllers/success_messages_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SuccessMessagesController < ApplicationController
+  def index
+    render json: 'Success'
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  config.action_mailer.perform_deliveries = true
+  config.action_mailer.perform_deliveries = false
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_caching = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,9 +33,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  config.action_mailer.perform_deliveries = false
+  config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,12 +3,10 @@ Rails.application.routes.draw do
     skip_controllers :applications, :authorizations, :authorized_applications, :tokens, :token_info
   end
 
-  devise_for :users, skip: [:registrations, :sessions, :passwords], skip_helpers: true
-
   namespace :api do
     namespace :v1 do
-      devise_for :users, controllers: {
-        confirmations: :confirmations
+      devise_for :users, skip: [:registrations, :passwords], skip_helpers: true, controllers: {
+        confirmations: 'api/v1/confirmations'
       }
       use_doorkeeper do
         controllers tokens: 'tokens'
@@ -23,4 +21,5 @@ Rails.application.routes.draw do
 
   resources :public_items, only: :index
   resources :private_items, only: :index
+  resources :success_messages, only: :index
 end

--- a/spec/requests/private_items_controller_spec.rb
+++ b/spec/requests/private_items_controller_spec.rb
@@ -5,19 +5,18 @@ require 'rails_helper'
 RSpec.describe PrivateItemsController, type: :request do
   describe 'GET#index' do
     context 'when the user is not signed in' do
-      it 'redirects to the root page' do
+      it 'returns unauthorized error' do
         get private_items_path
 
-        expect(response).to have_http_status(:found)
-        expect(response).to redirect_to('/')
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
+    # TODO: configure mock token for Doorkeeper integration
     context 'when the user is signed in' do
       it 'returns success status' do
-        sign_in Fabricate(:user)
-
-        get private_items_path
+        header, = create_token_header
+        get private_items_path, headers: header
 
         expect(response).to have_http_status(:success)
       end

--- a/spec/support/oauth_helpers.rb
+++ b/spec/support/oauth_helpers.rb
@@ -35,4 +35,13 @@ module OAuthHelpers
       refresh_token: refresh_token
     }
   end
+
+  def create_token_header(user = nil)
+    user ||= Fabricate(:user)
+
+    application = Fabricate(:application)
+    access_token = Fabricate(:access_token, resource_owner_id: user.id, application_id: application.id)
+
+    [{ 'Authorization' => "Bearer #{access_token.token}" }, user]
+  end
 end


### PR DESCRIPTION
- close #40

## What happened 👀

Configure `routes` to enable email confirmation with a link feature. I also added a simple controller to display the success messages after a user confirms the email.

## Insight 📝

- Disable sending confirmation emails in `Development` environment.
- Bring `devise_for :users` block at the top level to `API > V1`.
- Configure routes for Devise's confirmation controller.
- Add a new `success_messages_controller` for displaying a simple success message after a user confirms their email.

## Proof Of Work 📹


https://github.com/nimblehq/ic-rails-phong-bliss/assets/22606906/046060d8-d8d8-4884-b7b2-5e4c9e7cacee


