### PR TITLE
[#14][#13] [Backend] [API] As a user, I can view my uploaded keywords with pagination

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -3,8 +3,9 @@
 module Api
   module V1
     class ApplicationController < ActionController::API
-      include Pundit::Authorization
       include ErrorRenderable
+      include Pagy::Backend
+      include Pundit::Authorization
 
       before_action :doorkeeper_authorize!
 
@@ -12,6 +13,25 @@ module Api
 
       def current_user
         @current_user ||= User.find_by(id: doorkeeper_token[:resource_owner_id])
+      end
+
+      def paginated_authorized(klass)
+        pagy(policy_scope(klass), pagination_params)
+      end
+
+      def meta_from_pagination(pagination)
+        {
+          page: pagination.page,
+          per_page: pagination.items,
+          total_items: pagination.count
+        }
+      end
+
+      def pagination_params
+        {
+          page: params[:page],
+          items: params[:per_page]
+        }
       end
     end
   end

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -3,12 +3,11 @@
 module Api
   module V1
     class KeywordsController < ApplicationController
-      include Pagy::Backend
       before_action :authorize!
 
       def index
-        render json: KeywordSerializer.new(keywords, meta: meta_from_pagy(pagy))
-        pagy, keywords = pagy(policy_scope(Keyword), pagination_params)
+        pagination, keywords = paginated_authorized(Keyword)
+        render json: KeywordSerializer.new(keywords, meta: meta_from_pagination(pagination))
       end
 
       def create

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -3,11 +3,12 @@
 module Api
   module V1
     class KeywordsController < ApplicationController
+      include Pagy::Backend
       before_action :authorize!
 
       def index
-        keywords = policy_scope(Keyword)
-        render json: KeywordSerializer.new(keywords).serializable_hash.to_json
+        render json: KeywordSerializer.new(keywords, meta: meta_from_pagy(pagy))
+        pagy, keywords = pagy(policy_scope(Keyword), pagination_params)
       end
 
       def create

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,4 +1,4 @@
 #frozen_string_literal: true
 
-Pagy::DEFAULT[:page]   = 1
-Pagy::DEFAULT[:items]  = 10
+Pagy::DEFAULT[:page] = 1
+Pagy::DEFAULT[:items] = 10

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,4 @@
+#frozen_string_literal: true
+
+Pagy::DEFAULT[:page]   = 1
+Pagy::DEFAULT[:items]  = 10

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
           response_body = JSON.parse(response.body, symbolize_names: true)
           expect(response_body[:data].count).to eq 3
         end
+
+        it 'returns the correct meta data' do
+          user = Fabricate(:user)
+          Fabricate.times(3, :keyword, user: user)
+          get api_v1_keywords_path, params: { page: 1, per_page: 2 }, headers: create_token_header(user)
+          response_body = JSON.parse(response.body, symbolize_names: true)
+
+          expect(response_body[:meta]).to eq(page: 1, per_page: 2, total_items: 3)
+        end
       end
 
       context 'given the user has no keyword' do
@@ -44,6 +53,14 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
 
           response_body = JSON.parse(response.body, symbolize_names: true)
           expect(response_body[:data].count).to eq 0
+        end
+
+        it 'returns the correct meta data' do
+          Fabricate(:keyword)
+          get api_v1_keywords_path, params: { page: 1, per_page: 2 }, headers: create_token_header
+          response_body = JSON.parse(response.body, symbolize_names: true)
+
+          expect(response_body[:meta]).to eq(page: 1, per_page: 2, total_items: 0)
         end
       end
     end

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
           expect(response_body[:data].count).to eq 3
         end
 
-        it 'returns the correct meta data' do
+        it 'returns metadata with page = 1, per_page = 2 and total_items = 3' do
           user = Fabricate(:user)
           Fabricate.times(3, :keyword, user: user)
           get api_v1_keywords_path, params: { page: 1, per_page: 2 }, headers: create_token_header(user)
@@ -55,7 +55,7 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
           expect(response_body[:data].count).to eq 0
         end
 
-        it 'returns the correct meta data' do
+        it 'returns metadata with page = 1, per_page = 2 and total_items = 0' do
           Fabricate(:keyword)
           get api_v1_keywords_path, params: { page: 1, per_page: 2 }, headers: create_token_header
           response_body = JSON.parse(response.body, symbolize_names: true)


### PR DESCRIPTION
- close #13 
- close #14  

## What happened 👀

Use the gem`pagy` to implement pagination on the endpoint `keyword`

## Insight 📝

- Add new param `pagination_params`.
- Add new meta to contain current page, page size, and total number of items
- Write test for pagination.

## Proof Of Work 📹

<img width="811" alt="Screenshot 2023-06-23 at 09 30 50" src="https://github.com/nimblehq/ic-rails-phong-bliss/assets/22606906/b0e56fa7-e41a-4cb0-a235-cf7c5b7732d3">


