### PR TITLE
[#18][#19] [API] As a user, I can access my keyword details

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -10,6 +10,16 @@ module Api
 
       before_action :doorkeeper_authorize!
 
+      def raw_resources(klass, policy_scope_klass = nil)
+        resolve_policy_scope(klass, policy_scope_klass)
+      end
+
+      def resolve_policy_scope(scope, policy_scope_klass)
+        return policy_scope(scope) unless policy_scope_klass
+
+        policy_scope_klass.new(current_user, scope).resolve
+      end
+
       private
 
       def current_user

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -4,6 +4,7 @@ module Api
   module V1
     class ApplicationController < ActionController::API
       include ErrorRenderable
+      include Rescuable
       include Pagy::Backend
       include Pundit::Authorization
 

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -10,16 +10,6 @@ module Api
 
       before_action :doorkeeper_authorize!
 
-      def raw_resources(klass, policy_scope_klass = nil)
-        resolve_policy_scope(klass, policy_scope_klass)
-      end
-
-      def resolve_policy_scope(scope, policy_scope_klass)
-        return policy_scope(scope) unless policy_scope_klass
-
-        policy_scope_klass.new(current_user, scope).resolve
-      end
-
       private
 
       def current_user
@@ -43,6 +33,16 @@ module Api
           page: params[:page],
           items: params[:per_page]
         }
+      end
+
+      def authorized_resources(klass, policy_scope_klass = nil)
+        resolve_policy_scope(klass, policy_scope_klass)
+      end
+
+      def resolve_policy_scope(scope, policy_scope_klass)
+        return policy_scope(scope) unless policy_scope_klass
+
+        policy_scope_klass.new(current_user, scope).resolve
       end
     end
   end

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -23,7 +23,7 @@ module Api
       end
 
       def show
-        keyword = raw_resources(Keyword).find(params[:id])
+        keyword = authorized_resources(Keyword).find(params[:id])
         options = { include: [:source] }
 
         render json: KeywordDetailSerializer.new(keyword, options).serializable_hash.to_json

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -23,8 +23,16 @@ module Api
       end
 
       def show
-        keyword = Keyword.find_by(id: params[:id])
-        render json: KeywordDetailSerializer.new(keyword).serializable_hash.to_json
+        keyword = Keyword.find_by(user: current_user, id: params[:id])
+
+        if keyword
+          render json: KeywordDetailSerializer.new(keyword).serializable_hash.to_json
+        else
+          render_errors(
+            details: [I18n.t('keyword.not_found')],
+            status: :not_found
+          )
+        end
       end
 
       private

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -23,17 +23,14 @@ module Api
       end
 
       def show
-        keyword = Keyword.find_by(user: current_user, id: params[:id])
-
-        if keyword
-          options = { :include => [:source] }
-          render json: KeywordDetailSerializer.new(keyword, options).serializable_hash.to_json
-        else
-          render_errors(
-            details: [I18n.t('keyword.not_found')],
-            status: :not_found
-          ) 
-        end
+        keyword = policy_scope(Keyword).find(params[:id])
+        options = { include: [:source] }
+        render json: KeywordDetailSerializer.new(keyword, options).serializable_hash.to_json
+      rescue ActiveRecord::RecordNotFound
+        render_errors(
+          details: [I18n.t('keyword.not_found')],
+          status: :not_found
+        )
       end
 
       private

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -27,11 +27,6 @@ module Api
         options = { include: [:source] }
 
         render json: KeywordDetailSerializer.new(keyword, options).serializable_hash.to_json
-      rescue ActiveRecord::RecordNotFound
-        render_errors(
-          details: [I18n.t('keyword.not_found')],
-          status: :not_found
-        )
       end
 
       private

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -22,6 +22,11 @@ module Api
         end
       end
 
+      def show
+        keyword = Keyword.find_by(id: params[:id])
+        render json: KeywordDetailSerializer.new(keyword).serializable_hash.to_json
+      end
+
       private
 
       def authorize!

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -25,6 +25,7 @@ module Api
       def show
         keyword = policy_scope(Keyword).find(params[:id])
         options = { include: [:source] }
+
         render json: KeywordDetailSerializer.new(keyword, options).serializable_hash.to_json
       rescue ActiveRecord::RecordNotFound
         render_errors(

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -26,12 +26,13 @@ module Api
         keyword = Keyword.find_by(user: current_user, id: params[:id])
 
         if keyword
-          render json: KeywordDetailSerializer.new(keyword).serializable_hash.to_json
+          options = { :include => [:source] }
+          render json: KeywordDetailSerializer.new(keyword, options).serializable_hash.to_json
         else
           render_errors(
             details: [I18n.t('keyword.not_found')],
             status: :not_found
-          )
+          ) 
         end
       end
 

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -23,7 +23,7 @@ module Api
       end
 
       def show
-        keyword = policy_scope(Keyword).find(params[:id])
+        keyword = raw_resources(Keyword).find(params[:id])
         options = { include: [:source] }
 
         render json: KeywordDetailSerializer.new(keyword, options).serializable_hash.to_json

--- a/app/controllers/concerns/api/v1/error_renderable.rb
+++ b/app/controllers/concerns/api/v1/error_renderable.rb
@@ -5,13 +5,19 @@ module Api
     module ErrorRenderable
       private
 
-      def render_error(detail, source: nil, status: :unprocessable_entity)
-        error = build_error(detail: detail, source: source)
-        render_errors [error], status
+      def build_errors(details:, source: nil, meta: nil, code: nil)
+        {
+          source: { parameter: source }.compact,
+          details: details,
+          code: code,
+          meta: meta
+        }.compact_blank!
       end
 
-      def render_errors(jsonapi_errors, status = :unprocessable_entity)
-        render json: { errors: jsonapi_errors }, status: status
+      def render_errors(details:, source: nil, meta: nil, status: :unprocessable_entity, code: nil)
+        errors = build_errors(details: details, source: source, meta: meta, code: code)
+
+        render json: { errors: errors }, status: status
       end
     end
   end

--- a/app/controllers/concerns/api/v1/rescuable.rb
+++ b/app/controllers/concerns/api/v1/rescuable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Api
   module V1
     module Rescuable

--- a/app/controllers/concerns/api/v1/rescuable.rb
+++ b/app/controllers/concerns/api/v1/rescuable.rb
@@ -1,0 +1,16 @@
+module Api
+  module V1
+    module Rescuable
+      extend ActiveSupport::Concern
+
+      included do
+        rescue_from ActiveRecord::RecordNotFound do
+          render_errors(
+            details: [I18n.t('api.errors.not_found')],
+            status: :not_found
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/api/v1/rescuable.rb
+++ b/app/controllers/concerns/api/v1/rescuable.rb
@@ -7,6 +7,10 @@ module Api
 
       included do
         rescue_from ActiveRecord::RecordNotFound do
+          render_not_found_error
+        end
+
+        def render_not_found_error
           render_errors(
             details: [I18n.t('api.errors.not_found')],
             status: :not_found

--- a/app/controllers/concerns/api/v1/rescuable.rb
+++ b/app/controllers/concerns/api/v1/rescuable.rb
@@ -6,16 +6,14 @@ module Api
       extend ActiveSupport::Concern
 
       included do
-        rescue_from ActiveRecord::RecordNotFound do
-          render_not_found_error
-        end
+        rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_error
+      end
 
-        def render_not_found_error
-          render_errors(
-            details: [I18n.t('api.errors.not_found')],
-            status: :not_found
-          )
-        end
+      def render_not_found_error
+        render_errors(
+          details: [I18n.t('api.errors.not_found')],
+          status: :not_found
+        )
       end
     end
   end

--- a/app/policies/keyword_policy.rb
+++ b/app/policies/keyword_policy.rb
@@ -15,6 +15,10 @@ class KeywordPolicy < ApplicationPolicy
     user_valid?
   end
 
+  def show?
+    user_valid?
+  end
+
   private
 
   def user_valid?

--- a/app/policies/keyword_policy.rb
+++ b/app/policies/keyword_policy.rb
@@ -22,6 +22,6 @@ class KeywordPolicy < ApplicationPolicy
   private
 
   def user_valid?
-    user && !user.id.nil? && !user.email.nil?
+    user&.id.present? && user&.email.present?
   end
 end

--- a/app/serializers/keyword_detail_serializer.rb
+++ b/app/serializers/keyword_detail_serializer.rb
@@ -9,5 +9,6 @@ class KeywordDetailSerializer < ApplicationSerializer
   attributes :result_urls
   attributes :total_link_count
   attributes :html
+
   has_one :source
 end

--- a/app/serializers/keyword_detail_serializer.rb
+++ b/app/serializers/keyword_detail_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class KeywordDetailSerializer < ApplicationSerializer
+  attributes :name
+  attributes :ads_top_count
+  attributes :ads_page_count
+  attributes :ads_top_urls
+  attributes :result_count
+  attributes :result_urls
+  attributes :total_link_count
+  attributes :html
+  attributes :source
+end

--- a/app/serializers/keyword_detail_serializer.rb
+++ b/app/serializers/keyword_detail_serializer.rb
@@ -9,5 +9,5 @@ class KeywordDetailSerializer < ApplicationSerializer
   attributes :result_urls
   attributes :total_link_count
   attributes :html
-  attributes :source
+  has_one :source
 end

--- a/app/serializers/source_serializer.rb
+++ b/app/serializers/source_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class SourceSerializer < ApplicationSerializer
+  attributes :name
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,3 +36,5 @@ en:
     validation:
       wrong_count: 'The CSV file should contain between 1 and 1000 keywords'
       wrong_type: 'Please ensure the provided file type is CSV'
+  keyword:
+    not_found: "Keyword not found"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,5 +36,6 @@ en:
     validation:
       wrong_count: 'The CSV file should contain between 1 and 1000 keywords'
       wrong_type: 'Please ensure the provided file type is CSV'
-  keyword:
-    not_found: "Keyword not found"
+  api:
+    errors:
+      not_found: "Item not found"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
         controllers tokens: 'tokens'
         skip_controllers :authorizations, :applications, :authorized_applications, :token_info, :tokens, :confirmations
       end
-      resources :keywords, only: [:index, :create]
+      resources :keywords, only: [:index, :create, :show]
       resources :private_items, only: :index
       resources :tokens, only: [:create]
       resources :registrations, only: [:create]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,7 +29,6 @@ ActiveRecord::Schema.define(version: 2023_06_20_095911) do
     t.string "html"
     t.string "status", default: "in_progress", null: false
     t.bigint "source_id"
-    t.integer "status", default: 0, null: false
     t.index ["source_id"], name: "index_keywords_on_source_id"
     t.index ["user_id"], name: "index_keywords_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2023_06_20_095911) do
     t.string "html"
     t.string "status", default: "in_progress", null: false
     t.bigint "source_id"
+    t.integer "status", default: 0, null: false
     t.index ["source_id"], name: "index_keywords_on_source_id"
     t.index ["user_id"], name: "index_keywords_on_user_id"
   end

--- a/spec/fabricators/keyword_fabricator.rb
+++ b/spec/fabricators/keyword_fabricator.rb
@@ -5,3 +5,16 @@ Fabricator(:keyword) do
   name { FFaker::FreedomIpsum.word }
   user { Fabricate(:user) }
 end
+
+
+Fabricator(:keyword_parsed, from: :keyword) do
+  status :parsed
+  ads_top_count { FFaker.rand 9 }
+  ads_page_count { FFaker.rand 9 }
+  ads_top_urls(rand: 9) { FFaker::Internet.http_url }
+  result_count  { FFaker.rand 9 }
+  result_urls(rand: 9) { FFaker::Internet.http_url }
+  total_link_count { FFaker.rand 9 }
+  html { FFaker::HTMLIpsum.body }
+  source { Fabricate(:source) }
+end

--- a/spec/fabricators/keyword_fabricator.rb
+++ b/spec/fabricators/keyword_fabricator.rb
@@ -6,13 +6,12 @@ Fabricator(:keyword) do
   user { Fabricate(:user) }
 end
 
-
 Fabricator(:keyword_parsed, from: :keyword) do
   status :parsed
   ads_top_count { FFaker.rand 9 }
   ads_page_count { FFaker.rand 9 }
   ads_top_urls(rand: 9) { FFaker::Internet.http_url }
-  result_count  { FFaker.rand 9 }
+  result_count { FFaker.rand 9 }
   result_urls(rand: 9) { FFaker::Internet.http_url }
   total_link_count { FFaker.rand 9 }
   html { FFaker::HTMLIpsum.body }

--- a/spec/fabricators/keyword_fabricator.rb
+++ b/spec/fabricators/keyword_fabricator.rb
@@ -15,5 +15,6 @@ Fabricator(:keyword_parsed, from: :keyword) do
   result_urls(rand: 9) { FFaker::Internet.http_url }
   total_link_count { FFaker.rand 9 }
   html { FFaker::HTMLIpsum.body }
+
   source { Fabricate(:source) }
 end

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -165,7 +165,6 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
   describe 'GET#show' do
     context 'when CSV file is valid' do
       it 'returns success status' do
-        stub_request(:get, %r{google.com/search})
         keyword = Fabricate(:keyword_parsed)
         user = keyword.user
         get api_v1_keyword_path(keyword.id), headers: create_token_header(user)
@@ -174,7 +173,6 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
       end
 
       it 'returns same ads_page_count as the keyword' do
-        stub_request(:get, %r{google.com/search})
         keyword = Fabricate(:keyword_parsed)
         user = keyword.user
         get api_v1_keyword_path(keyword.id), headers: create_token_header(user)
@@ -183,7 +181,6 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
       end
 
       it 'returns json with source as an included relationship' do
-        stub_request(:get, %r{google.com/search})
         keyword = Fabricate(:keyword_parsed)
         user = keyword.user
         get api_v1_keyword_path(keyword.id), headers: create_token_header(user)
@@ -194,7 +191,6 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
 
     context 'when keyword does not belonged to the user' do
       it 'returns not found status' do
-        stub_request(:get, %r{google.com/search})
         keyword = Fabricate(:keyword_parsed)
         get api_v1_keyword_path(keyword.id), headers: create_token_header
 
@@ -202,7 +198,6 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
       end
 
       it 'returns the keyword.not_found error' do
-        stub_request(:get, %r{google.com/search})
         keyword = Fabricate(:keyword_parsed)
         get api_v1_keyword_path(keyword.id), headers: create_token_header
 

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -217,5 +217,13 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context 'given a non-logged in user' do
+      it 'returns an unauthorized error' do
+        get api_v1_keyword_path(0)
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -197,11 +197,11 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
         expect(response).to have_http_status(:not_found)
       end
 
-      it 'returns the keyword.not_found error' do
+      it 'returns the api.errors.not_found error' do
         keyword = Fabricate(:keyword_parsed)
         get api_v1_keyword_path(keyword.id), headers: create_token_header
 
-        expect(JSON.parse(response.body)['errors']['details']).to include(I18n.t('keyword.not_found'))
+        expect(JSON.parse(response.body)['errors']['details']).to include(I18n.t('api.errors.not_found'))
       end
     end
 

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -181,6 +181,15 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
 
         expect(JSON.parse(response.body)['data']['attributes']['ads_page_count']).to eq(keyword.reload.ads_page_count)
       end
+
+      it 'returns json with source as an included relationship' do
+        stub_request(:get, %r{google.com/search})
+        keyword = Fabricate(:keyword_parsed)
+        user = keyword.user
+        get api_v1_keyword_path(keyword.id), headers: create_token_header(user)
+
+        expect(JSON.parse(response.body)['included'].find { |included| included['type'] == 'source' }['attributes']['name']).to eq(keyword.reload.source.name)
+      end
     end
 
     context 'when keyword does not belonged to the user' do

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -161,4 +161,24 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
       end
     end
   end
+
+  describe 'GET#show' do
+    context 'when CSV file is valid' do
+      it 'returns success status' do
+        stub_request(:get, %r{google.com/search})
+        keyword = Fabricate(:keyword_parsed)
+        get api_v1_keyword_path(:id => keyword.id), headers: create_token_header
+
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns success status' do
+        stub_request(:get, %r{google.com/search})
+        keyword = Fabricate(:keyword_parsed)
+        get api_v1_keyword_path(:id => keyword.id), headers: create_token_header
+
+        expect(JSON.parse(response.body)).to eq('')
+      end
+    end
+  end
 end


### PR DESCRIPTION
- close #18 
- close #19 

## What happened 👀

Call `GET` to `api/v1/keywords/:id` can return the keyword detail belongs to the user.

## Insight 📝

- Add `show` to KeywordController.
- Add new serializer `KeywordDetailSerializer`.
- Modify Error response to fix some bug.
- Add `Rescuable` to support future error catching.

## Proof Of Work 📹

<img width="959" alt="Screen Shot 2023-06-23 at 15 18 32" src="https://github.com/nimblehq/ic-rails-phong-bliss/assets/6356137/ce2f33b6-3425-44c2-ae0f-a147e062a4ff">
