### PR TITLE
[#17] [Backend] Automatically search uploaded keywords on Google in background queue

### DIFF
--- a/app/jobs/google/search_keyword_job.rb
+++ b/app/jobs/google/search_keyword_job.rb
@@ -16,7 +16,7 @@ module Google
       else
         keyword.update({ status: :failed })
 
-        raise Google::Errors::SearchKeywordError unless search_result
+        raise Google::Errors::SearchKeywordError
       end
     end
   end

--- a/app/jobs/google/search_keyword_job.rb
+++ b/app/jobs/google/search_keyword_job.rb
@@ -15,6 +15,8 @@ module Google
         keyword.update search_result.merge(status: :parsed)
       else
         keyword.update({ status: :failed })
+
+        raise Google::Errors::SearchKeywordError unless search_result
       end
     end
   end

--- a/app/lib/google/errors/search_keyword_error.rb
+++ b/app/lib/google/errors/search_keyword_error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Google
+  module Errors
+    class SearchKeywordError < StandardError; end
+  end
+end

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -11,11 +11,6 @@ class Keyword < ApplicationRecord
   private
 
   def perform_search
-    # TODO: Perform "later" for all env
-    if ENV['RAILS_ENV'] == 'test'
-      Google::SearchKeywordJob.perform_later id
-    else
-      Google::SearchKeywordJob.perform_now id
-    end
+    Google::SearchKeywordJob.perform_later id
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,3 +3,7 @@
 :queues:
   - [default, 1]
   - [mailers, 2]
+
+development:
+  :queues:
+    - [development_default, 1]

--- a/spec/jobs/google/search_keyword_job_spec.rb
+++ b/spec/jobs/google/search_keyword_job_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Google::SearchKeywordJob, type: :job do
         expect(described_class).to have_received(:perform_now).with(keyword_id).exactly(:once)
       end
 
-      it 'raises SearchKeywordError' do
+      it 'raises SearchKeywordError to trigger Sidekiq retry' do
         stub_request(:get, %r{google.com/search}).to_return(status: 422)
         keyword = Fabricate(:keyword)
 

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
           stub_request(:get, %r{google.com/search}).to_return(status: 422)
 
           params = { 'file' => fixture_file_upload('csv/valid.csv') }
+        rescue Google::Errors::SearchKeywordError
           perform_enqueued_jobs do
             post api_v1_keywords_path, params: params, headers: create_token_header
           end


### PR DESCRIPTION
- close #17

## What happened 👀

Keyword search now perform in background.

## Insight 📝

- Add `KeywordSearchError` for when Google crawl failed.
  - Raising error for `Sidekiq` will automatically add the job to [retry queue](https://www.rubydoc.info/gems/sidekiq/Sidekiq/JobRetry) default to 25 retries.
  - Update Keyword status to `failed`.

## Proof Of Work 📹

<img width="1136" alt="Screen Shot 2023-06-27 at 16 36 27" src="https://github.com/nimblehq/ic-rails-phong-bliss/assets/6356137/89406ceb-7fa4-4939-a148-30df4386b4c0">
<img width="1392" alt="Screen Shot 2023-06-27 at 16 37 39" src="https://github.com/nimblehq/ic-rails-phong-bliss/assets/6356137/17f6d2c6-f21a-4b37-87b0-10b5df30bc83">

Background demo:

https://github.com/nimblehq/ic-rails-phong-bliss/assets/6356137/90ed5127-0f74-4d67-8190-085d3e4e389e

