### PR TITLE
[#64] [Chore] Source.name should be unique and case insensitive

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Source < ApplicationRecord
+  include Discard::Model
+
   has_many :keywords, inverse_of: :source, dependent: :nullify
 
   validates :name, uniqueness: { case_sensitive: false }

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -2,4 +2,6 @@
 
 class Source < ApplicationRecord
   has_many :keywords, inverse_of: :source, dependent: :nullify
+
+  validates :name, uniqueness: { case_sensitive: false }
 end

--- a/db/migrate/20230609095923_keyword.rb
+++ b/db/migrate/20230609095923_keyword.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Keyword < ActiveRecord::Migration[7.0]
   def change
     create_table :keywords do |t|

--- a/db/migrate/20230613043615_add_confirmable_to_devise.rb
+++ b/db/migrate/20230613043615_add_confirmable_to_devise.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddConfirmableToDevise < ActiveRecord::Migration[7.0]
   def change
     add_column :users, :confirmation_token, :string

--- a/db/migrate/20230620095910_create_sources.rb
+++ b/db/migrate/20230620095910_create_sources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateSources < ActiveRecord::Migration[7.0]
   def change
     create_table :sources do |t|

--- a/db/migrate/20230620095911_add_search_to_keyword.rb
+++ b/db/migrate/20230620095911_add_search_to_keyword.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSearchToKeyword < ActiveRecord::Migration[7.0]
   def change
     change_table :keywords do |t|

--- a/db/migrate/20230628044856_add_unique_index_on_name_to_sources.rb
+++ b/db/migrate/20230628044856_add_unique_index_on_name_to_sources.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexOnNameToSources < ActiveRecord::Migration[7.0]
+  def change
+    update_existing_sources
+
+    change_column :sources, :name, :string, unique: true, null: false
+    add_index :sources, :name, unique: true
+  end
+
+  private
+
+  def update_existing_sources
+    Source.with_discarded.group_by { |source| source.name.downcase }
+                         .each do |_name, source|
+      next unless source.size > 1
+
+      source.each_with_index do |source, index|
+        source.name = "#{source.name} #{index + 1}"
+        source.save!(validate: false)
+      end
+    end
+  end
+end

--- a/db/migrate/20230628044856_add_unique_to_sources.rb
+++ b/db/migrate/20230628044856_add_unique_to_sources.rb
@@ -1,0 +1,6 @@
+class AddUniqueToSources < ActiveRecord::Migration[7.0]
+  def change
+    change_column :sources, :name, :string, unique: true, null: false
+    add_index :sources, :name, unique: true
+  end
+end

--- a/db/migrate/20230628044856_add_unique_to_sources.rb
+++ b/db/migrate/20230628044856_add_unique_to_sources.rb
@@ -1,6 +1,0 @@
-class AddUniqueToSources < ActiveRecord::Migration[7.0]
-  def change
-    change_column :sources, :name, :string, unique: true, null: false
-    add_index :sources, :name, unique: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_20_095911) do
+ActiveRecord::Schema.define(version: 2023_06_28_044856) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,9 +62,10 @@ ActiveRecord::Schema.define(version: 2023_06_20_095911) do
   end
 
   create_table "sources", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_sources_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/fabricators/source_fabricator.rb
+++ b/spec/fabricators/source_fabricator.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Fabricator(:source) do
-  name 'MyWebsite'
+  name { FFaker::Company.unique.name }
 end

--- a/spec/forms/csv_upload_form_spec.rb
+++ b/spec/forms/csv_upload_form_spec.rb
@@ -72,8 +72,9 @@ RSpec.describe CsvUploadForm, type: :form do
     context 'given a file with 9 keywords and 1 blank' do
       it 'saves 9 keywords with the correct user' do
         user = Fabricate(:user)
+        source = Fabricate(:source)
         form = described_class.new(user)
-        form.save(file_fixture('csv/blank.csv'), nil)
+        form.save(file_fixture('csv/blank.csv'), source.name)
 
         expect(keyword_for_user(user).count).to eq(9)
       end

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -4,22 +4,20 @@ require 'rails_helper'
 
 RSpec.describe Source, type: :model do
   context 'when creating two Sources with different cases' do
-    it 'does NOT create a second source' do
-      described_class.find_or_create_by({ name: 'nimble' })
-
+    it 'saves 1 source' do
       expect do
+        described_class.find_or_create_by({ name: 'nimble' })
         described_class.find_or_create_by({ name: 'nImBle' })
-      end.not_to change(described_class, :count)
+      end.to change(described_class, :count).by(1)
     end
   end
 
   context 'when creating two Sources with different names' do
     it 'saves 2 sources' do
-      described_class.find_or_create_by({ name: 'nimble1' })
-
       expect do
+        described_class.find_or_create_by({ name: 'nimble1' })
         described_class.find_or_create_by({ name: 'nimble2' })
-      end.to change(described_class, :count).by(1)
+      end.to change(described_class, :count).by(2)
     end
   end
 end

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Source, type: :model do
-  context 'when saving two Sources with different cases' do
-    it 'saves only one Source' do
+  context 'when creating two Sources with different cases' do
+    it 'does NOT create a second source' do
       described_class.find_or_create_by({ name: 'nimble' })
 
       expect do
@@ -13,8 +13,8 @@ RSpec.describe Source, type: :model do
     end
   end
 
-  context 'when saving two Sources with different names' do
-    it 'saves two Sources' do
+  context 'when creating two Sources with different names' do
+    it 'saves 2 sources' do
       described_class.find_or_create_by({ name: 'nimble1' })
 
       expect do

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Source, type: :model do
+  context 'when saving two Sources with different cases' do
+    it 'saves only one Source' do
+      described_class.find_or_create_by({ name: 'nimble' })
+
+      expect do
+        described_class.find_or_create_by({ name: 'nImBle' })
+      end.not_to change(described_class, :count)
+    end
+  end
+
+  context 'when saving two Sources with different names' do
+    it 'saves two Sources' do
+      described_class.find_or_create_by({ name: 'nimble1' })
+
+      expect do
+        described_class.find_or_create_by({ name: 'nimble2' })
+      end.to change(described_class, :count).by(1)
+    end
+  end
+end


### PR DESCRIPTION
- close #64 

## What happened 👀

Make `Source.name` unique and case insensitive.

## Insight 📝

- Create `AddUniqueToSources` DB migration.
- Add `case-sensitive: false` to `Source`.

## Proof Of Work 📹

Test passes and App behaves the same.