### PR TITLE
[#72] [Chore] Update Sidekiq settings to allow `production` run 

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,3 +7,7 @@
 development:
   :queues:
     - [development_default, 1]
+
+production:
+  :queues:
+    - [production_default, 1]


### PR DESCRIPTION
- close #72 

## What happened 👀

- Add Sidekiq queue for `production` environment.

## Insight 📝

`N/A`

## Proof Of Work 📹

Runs correctly on Heroku.

<img width="560" alt="Screen Shot 2023-07-06 at 10 10 07" src="https://github.com/nimblehq/ic-rails-phong-bliss/assets/6356137/c7fce244-c9f4-4254-a44b-46b699ce2b25">
