### PR TITLE
[#24][#25] As a user, I can view How many keywords have URLs in stored search result with specific word and number of matches

### DIFF
--- a/app/presenters/keyword_presenter.rb
+++ b/app/presenters/keyword_presenter.rb
@@ -9,19 +9,23 @@ class KeywordPresenter
   end
 
   def matching_adword_urls
-    return unless defined?(filter_params[:adwords_url_contains]) && filter_params[:adwords_url_contains]
+    return unless filter_params[:adwords_url_contains]
 
-    keyword.ads_top_urls.select { |item| item.downcase.include?(filter_params[:adwords_url_contains].downcase) }
+    adwords_url_contains = filter_params[:adwords_url_contains].downcase
+    keyword.ads_top_urls.select do |item|
+      item.downcase.include?(adwords_url_contains)
+    end
   rescue NoMethodError
     nil
   end
 
   def matching_result_urls
-    return unless filter_params[:word] && filter_params[:match_at_least]
+    return if filter_params[:word].blank? || filter_params[:match_at_least].blank?
 
-    keyword.result_urls.select { |item|
-      item.downcase.match("\\w*(#{filter_params[:word]}.*){#{filter_params[:match_at_least]},}")
-    }
+    word = filter_params[:word].downcase
+    keyword.result_urls.select do |item|
+      item.downcase.match("\\w*(#{word}.*){#{filter_params[:match_at_least]},}")
+    end
   rescue NoMethodError
     nil
   end

--- a/app/presenters/keyword_presenter.rb
+++ b/app/presenters/keyword_presenter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class KeywordPresenter
-  delegate :id, :name, :ads_top_urls, :created_at, :updated_at, to: :keyword
+  delegate :id, :name, :ads_top_urls, :result_urls, :created_at, :updated_at, to: :keyword
 
   def initialize(keyword, filter_params)
     @keyword = keyword
@@ -12,6 +12,18 @@ class KeywordPresenter
     return unless defined?(filter_params[:adwords_url_contains]) && filter_params[:adwords_url_contains]
 
     keyword.ads_top_urls.select { |item| item.downcase.include?(filter_params[:adwords_url_contains].downcase) }
+  rescue NoMethodError
+    nil
+  end
+
+  def matching_result_urls
+    return unless filter_params[:word] && filter_params[:match_at_least]
+
+    keyword.result_urls.select { |item|
+      item.downcase.match("\\w*(#{filter_params[:word]}.*){#{filter_params[:match_at_least]},}")
+    }
+  rescue NoMethodError
+    nil
   end
 
   private

--- a/app/queries/keywords_query.rb
+++ b/app/queries/keywords_query.rb
@@ -9,24 +9,31 @@ class KeywordsQuery
   end
 
   def call
-    if filter_params[:adwords_url_contains]
-      filter_ads_top_urls(filter_params[:adwords_url_contains])
-    elsif filter_params[:word] && filter_params[:match_at_least]
-      filter_result_urls(filter_params[:word], filter_params[:match_at_least])
-    else
-      scope
-    end
+    return filter_ads_top_urls if filter_params[:adwords_url_contains]
+
+    return filter_result_urls if filter_params[:word] && filter_params[:match_at_least]
+
+    scope
   rescue NoMethodError
     scope
   end
 
   private
 
-  def filter_ads_top_urls(word)
+  def filter_ads_top_urls
+    word = filter_params[:adwords_url_contains]&.downcase
+
+    return scope unless word
+
     scope.where("array_to_string(ads_top_urls, '||') ILIKE ?", "%#{word}%")
   end
 
-  def filter_result_urls(word, number_of_matches)
+  def filter_result_urls
+    word = filter_params[:word]
+    number_of_matches = filter_params[:match_at_least]
+
+    return scope if word.blank? || number_of_matches.blank?
+
     sub_query = Keyword.select('sub_table.id, sub_table.user_id')
                        .from(Keyword.select('id, user_id, unnest(result_urls) as result_url'), 'sub_table')
                        .where('result_url ~* ?', "(#{word}.*){#{number_of_matches},}")

--- a/app/queries/keywords_query.rb
+++ b/app/queries/keywords_query.rb
@@ -9,14 +9,28 @@ class KeywordsQuery
   end
 
   def call
-    return scope unless defined?(filter_params[:adwords_url_contains]) && filter_params[:adwords_url_contains]
-
-    filter_ads_top_urls(filter_params[:adwords_url_contains])
+    if filter_params[:adwords_url_contains]
+      filter_ads_top_urls(filter_params[:adwords_url_contains])
+    elsif filter_params[:word] && filter_params[:match_at_least]
+      filter_result_urls(filter_params[:word], filter_params[:match_at_least])
+    else
+      scope
+    end
+  rescue NoMethodError
+    scope
   end
 
   private
 
   def filter_ads_top_urls(word)
     scope.where("array_to_string(ads_top_urls, '||') ILIKE ?", "%#{word}%")
+  end
+
+  def filter_result_urls(word, number_of_matches)
+    sub_query = Keyword.select('sub_table.id, sub_table.user_id')
+                       .from(Keyword.select('id, user_id, unnest(result_urls) as result_url'), 'sub_table')
+                       .where('result_url ~* ?', "(#{word}.*){#{number_of_matches},}")
+
+    Keyword.joins("INNER JOIN (#{sub_query.to_sql}) sub_table ON keywords.id = sub_table.id").group(:id)
   end
 end

--- a/app/serializers/keyword_serializer.rb
+++ b/app/serializers/keyword_serializer.rb
@@ -8,10 +8,10 @@ class KeywordSerializer < ApplicationSerializer
              :result_urls
 
   attribute :matching_adword_urls, if: proc { |record|
-    defined?(record.matching_adword_urls) && record.matching_adword_urls.present?
+    record&.matching_adword_urls.present?
   }
 
   attribute :matching_result_urls, if: proc { |record|
-    defined?(record.matching_result_urls) && record.matching_result_urls.present?
+    record&.matching_result_urls.present?
   }
 end

--- a/app/serializers/keyword_serializer.rb
+++ b/app/serializers/keyword_serializer.rb
@@ -4,9 +4,14 @@ class KeywordSerializer < ApplicationSerializer
   attributes :name,
              :created_at,
              :updated_at,
-             :ads_top_urls
+             :ads_top_urls,
+             :result_urls
 
   attribute :matching_adword_urls, if: proc { |record|
     defined?(record.matching_adword_urls) && record.matching_adword_urls.present?
+  }
+
+  attribute :matching_result_urls, if: proc { |record|
+    defined?(record.matching_result_urls) && record.matching_result_urls.present?
   }
 end

--- a/spec/presenters/keyword_presenter_spec.rb
+++ b/spec/presenters/keyword_presenter_spec.rb
@@ -36,5 +36,16 @@ RSpec.describe KeywordPresenter do
         expect(result).to be_nil
       end
     end
+
+    context 'given result urls contain a word vpn' do
+      it 'returns matching_result_urls with 2 urls https://www.topvpn.com and https://www.nordvpn.com' do
+        result_urls = ['https://www.topvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+        keyword = Fabricate(:keyword, result_urls: result_urls)
+        filter_params = { word: 'vpn', match_at_least: '1' }
+        result = described_class.new(keyword, filter_params).matching_result_urls
+
+        expect(result).to eq(['https://www.topvpn.com', 'https://www.nordvpn.com'])
+      end
+    end
   end
 end

--- a/spec/presenters/keyword_presenter_spec.rb
+++ b/spec/presenters/keyword_presenter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe KeywordPresenter do
         filter_params = { adwords_url_contains: 'vpn' }
         result = described_class.new(keyword, filter_params).matching_adword_urls
 
-        expect(result).to eq(['https://www.thetopvpn.com', 'https://www.nordvpn.com'])
+        expect(result).to contain_exactly('https://www.thetopvpn.com', 'https://www.nordvpn.com')
       end
     end
 
@@ -37,14 +37,47 @@ RSpec.describe KeywordPresenter do
       end
     end
 
-    context 'given result urls contain a word vpn' do
+    context 'given result urls contain a word vpn and match_at_least is 1' do
       it 'returns matching_result_urls with 2 urls https://www.topvpn.com and https://www.nordvpn.com' do
         result_urls = ['https://www.topvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
         keyword = Fabricate(:keyword, result_urls: result_urls)
         filter_params = { word: 'vpn', match_at_least: '1' }
         result = described_class.new(keyword, filter_params).matching_result_urls
 
-        expect(result).to eq(['https://www.topvpn.com', 'https://www.nordvpn.com'])
+        expect(result).to contain_exactly('https://www.topvpn.com', 'https://www.nordvpn.com')
+      end
+    end
+
+    context 'given result urls contain a word vpn and match_at_least is 2' do
+      it 'returns matching_result_urls with 2 urls https://www.topvpn.com and https://www.nordvpn.com' do
+        result_urls = ['https://www.topvpn.com/VPN', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+        keyword = Fabricate(:keyword, result_urls: result_urls)
+        filter_params = { word: 'vpn', match_at_least: '2' }
+        result = described_class.new(keyword, filter_params).matching_result_urls
+
+        expect(result).to contain_exactly('https://www.topvpn.com/VPN')
+      end
+    end
+
+    context 'given word parameter is vpn and match_at_least is not exist' do
+      it 'returns nil' do
+        result_urls = ['https://www.topvpn.com/VPN', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+        keyword = Fabricate(:keyword, result_urls: result_urls)
+        filter_params = { word: 'vpn' }
+        result = described_class.new(keyword, filter_params).matching_result_urls
+
+        expect(result).to be_nil
+      end
+    end
+
+    context 'given match_at_least is 1 and word is not exist' do
+      it 'returns nil' do
+        result_urls = ['https://www.topvpn.com/VPN', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+        keyword = Fabricate(:keyword, result_urls: result_urls)
+        filter_params = { match_at_least: 'vpn' }
+        result = described_class.new(keyword, filter_params).matching_result_urls
+
+        expect(result).to be_nil
       end
     end
   end

--- a/spec/queries/keywords_query_spec.rb
+++ b/spec/queries/keywords_query_spec.rb
@@ -38,6 +38,30 @@ RSpec.describe KeywordsQuery, type: :query do
           expect(keywords.count).to eq 2
         end
       end
+
+      context 'given the user search for a word vpn and match at least 1' do
+        it 'test' do
+          user = Fabricate(:user)
+          result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+          keyword = Fabricate(:keyword, result_urls: result_urls, user: user)
+          filter_params = { word: 'vpn', match_at_least: '1' }
+          keywords = described_class.new(Keyword, filter_params).call
+
+          expect(keywords).to eq [keyword]
+        end
+      end
+
+      context 'given the user search for vpn word e and match at least 2' do
+        it 'test' do
+          user = Fabricate(:user)
+          result_urls = ['https://www.topvpn.com/vpn', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+          keyword = Fabricate(:keyword, result_urls: result_urls, user: user)
+          filter_params = { word: 'vpn', match_at_least: '2' }
+          keywords = described_class.new(Keyword, filter_params).call
+
+          expect(keywords).to eq [keyword]
+        end
+      end
     end
   end
 end

--- a/spec/queries/keywords_query_spec.rb
+++ b/spec/queries/keywords_query_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe KeywordsQuery, type: :query do
   describe '#call' do
-    context 'given the user searchs for ads_top_urls' do
+    context 'given the user searches for ads_top_urls' do
       context 'given ads_top_urls contain the filtering word vpn' do
         it 'returns 2 keywords' do
           ads_top_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
@@ -28,15 +28,15 @@ RSpec.describe KeywordsQuery, type: :query do
       end
 
       context 'given filter_params is nil' do
-        it 'returns Keyword scope' do
+        it 'returns all the Keywords' do
           keywords = described_class.new(Keyword, nil).call
 
-          expect(keywords).to eq Keyword
+          expect(keywords.all).to eq Keyword.all
         end
       end
     end
 
-    context 'given the user searchs for result_urls' do
+    context 'given the user searches for result_urls' do
       context 'given filtering with a word vpn and match at least 1' do
         it 'returns a keyword' do
           result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
@@ -60,7 +60,7 @@ RSpec.describe KeywordsQuery, type: :query do
       end
 
       context 'given there is no matched result' do
-        it 'returns empty' do
+        it 'is empty' do
           result_urls = ['https://www.topvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
           Fabricate(:keyword, result_urls: result_urls)
           filter_params = { word: 'vpn', match_at_least: '2' }
@@ -75,7 +75,7 @@ RSpec.describe KeywordsQuery, type: :query do
           filter_params = { word: 'vpn' }
           keywords = described_class.new(Keyword, filter_params).call
 
-          expect(keywords).to eq Keyword
+          expect(keywords.all).to eq Keyword.all
         end
       end
 

--- a/spec/queries/keywords_query_spec.rb
+++ b/spec/queries/keywords_query_spec.rb
@@ -4,12 +4,11 @@ require 'rails_helper'
 
 RSpec.describe KeywordsQuery, type: :query do
   describe '#call' do
-    context 'given user has keyword' do
+    context 'given the user searchs for ads_top_urls' do
       context 'given ads_top_urls contain the filtering word vpn' do
         it 'returns 2 keywords' do
-          user = Fabricate(:user)
           ads_top_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
-          Fabricate.times(2, :keyword, ads_top_urls: ads_top_urls, user: user)
+          Fabricate.times(2, :keyword, ads_top_urls: ads_top_urls)
           filter_params = { adwords_url_contains: 'vpn' }
           keywords = described_class.new(Keyword, filter_params).call
 
@@ -19,9 +18,8 @@ RSpec.describe KeywordsQuery, type: :query do
 
       context 'given ads_top_urls does not contain the filtering word apple' do
         it 'returns an empty array' do
-          user = Fabricate(:user)
           ads_top_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
-          Fabricate.times(2, :keyword, ads_top_urls: ads_top_urls, user: user)
+          Fabricate.times(2, :keyword, ads_top_urls: ads_top_urls)
           filter_params = { adwords_url_contains: 'apple' }
           keywords = described_class.new(Keyword, filter_params).call
 
@@ -30,37 +28,77 @@ RSpec.describe KeywordsQuery, type: :query do
       end
 
       context 'given filter_params is nil' do
-        it 'returns all keywords' do
-          user = Fabricate(:user)
-          Fabricate.times(2, :keyword, user: user)
+        it 'returns Keyword scope' do
           keywords = described_class.new(Keyword, nil).call
 
-          expect(keywords.count).to eq 2
+          expect(keywords).to eq Keyword
         end
       end
+    end
 
-      context 'given the user search for a word vpn and match at least 1' do
-        it 'test' do
-          user = Fabricate(:user)
+    context 'given the user searchs for result_urls' do
+      context 'given filtering with a word vpn and match at least 1' do
+        it 'returns a keyword' do
           result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
-          keyword = Fabricate(:keyword, result_urls: result_urls, user: user)
+          keyword = Fabricate(:keyword, result_urls: result_urls)
           filter_params = { word: 'vpn', match_at_least: '1' }
           keywords = described_class.new(Keyword, filter_params).call
 
-          expect(keywords).to eq [keyword]
+          expect(keywords).to contain_exactly(keyword)
         end
       end
 
-      context 'given the user search for vpn word e and match at least 2' do
-        it 'test' do
-          user = Fabricate(:user)
+      context 'given filtering with a word vpn and match at least 2' do
+        it 'returns a keyword' do
           result_urls = ['https://www.topvpn.com/vpn', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
-          keyword = Fabricate(:keyword, result_urls: result_urls, user: user)
+          keyword = Fabricate(:keyword, result_urls: result_urls)
           filter_params = { word: 'vpn', match_at_least: '2' }
           keywords = described_class.new(Keyword, filter_params).call
 
-          expect(keywords).to eq [keyword]
+          expect(keywords).to contain_exactly(keyword)
         end
+      end
+
+      context 'given there is no matched result' do
+        it 'returns empty' do
+          result_urls = ['https://www.topvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+          Fabricate(:keyword, result_urls: result_urls)
+          filter_params = { word: 'vpn', match_at_least: '2' }
+          keywords = described_class.new(Keyword, filter_params).call
+
+          expect(keywords).to be_empty
+        end
+      end
+
+      context 'given word parameter is vpn and match_at_least parameter nil' do
+        it 'returns Keyword scope' do
+          filter_params = { word: 'vpn' }
+          keywords = described_class.new(Keyword, filter_params).call
+
+          expect(keywords).to eq Keyword
+        end
+      end
+
+      context 'given match_at_least parameter is 1 and word parameter nil' do
+        it 'returns all the keywords' do
+          filter_params = { match_at_least: '1' }
+          keywords = described_class.new(Keyword, filter_params).call
+
+          expect(keywords.all).to eq Keyword.all
+        end
+      end
+    end
+
+    context 'given the user input 3 paramters adwords_url_contains, word and match_at_least' do
+      it 'returns results for the filter adwords_url_contains' do
+        ads_top_urls = ['https://www.google.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+        result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+        Fabricate(:keyword, result_urls: result_urls)
+        keyword = Fabricate(:keyword, ads_top_urls: ads_top_urls)
+        filter_params = { adwords_url_contains: 'vnexpress', word: 'google', match_at_least: '1' }
+        keywords = described_class.new(Keyword, filter_params).call
+
+        expect(keywords).to contain_exactly(keyword)
       end
     end
   end

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -134,33 +134,6 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
               expect(response_body[:meta]).to eq(page: 1, per_page: 1, total_items: 0)
             end
           end
-
-          context 'given user search for word vpn in result_urls' do
-            it 'returns keywords contains the matched urls' do
-              user = Fabricate(:user)
-              result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
-              Fabricate(:keyword, result_urls: result_urls, user: user)
-
-              params = { filter: { word: 'vpn', match_at_least: '1' }, page: 1, per_page: 1 }
-              get api_v1_keywords_path, params: params, headers: create_token_header(user)
-
-              response_body = JSON.parse(response.body, symbolize_names: true)
-              expect(response_body[:data][0][:attributes][:matching_result_urls]).to eq(['https://www.thetopvpn.com', 'https://www.nordvpn.com'])
-            end
-
-            it 'returns metadata with page = 1, per_page = 1 and total_item = 1' do
-              user = Fabricate(:user)
-              result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
-              Fabricate(:keyword, result_urls: result_urls, user: user)
-
-              params = { filter: { word: 'vpn', match_at_least: '1' }, page: 1, per_page: 1 }
-              get api_v1_keywords_path, params: params, headers: create_token_header(user)
-
-              response_body = JSON.parse(response.body, symbolize_names: true)
-
-              expect(response_body[:meta]).to eq(page: 1, per_page: 1, total_items: 1)
-            end
-          end
         end
 
         context 'given the user does not have any keyword' do
@@ -183,6 +156,172 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
             response_body = JSON.parse(response.body, symbolize_names: true)
 
             expect(response_body[:meta]).to eq(page: 1, per_page: 2, total_items: 0)
+          end
+        end
+      end
+
+      context 'given the user search for a specific word in result_urls' do
+        context 'given the user search for word vpn with match_at_least 1' do
+          it 'returns keywords contains the matched urls' do
+            user = Fabricate(:user)
+            result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+            Fabricate(:keyword, result_urls: result_urls, user: user)
+            params = { filter: { word: 'vpn', match_at_least: '1' }, page: 1, per_page: 1 }
+
+            get api_v1_keywords_path, params: params, headers: create_token_header(user)
+            response_body = JSON.parse(response.body, symbolize_names: true)
+
+            expect(response_body[:data][0][:attributes][:matching_result_urls]).to eq(['https://www.thetopvpn.com', 'https://www.nordvpn.com'])
+          end
+
+          it 'returns metadata with page = 1, per_page = 1 and total_item = 1' do
+            user = Fabricate(:user)
+            result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+            Fabricate(:keyword, result_urls: result_urls, user: user)
+            params = { filter: { word: 'vpn', match_at_least: '1' }, page: 1, per_page: 1 }
+
+            get api_v1_keywords_path, params: params, headers: create_token_header(user)
+            response_body = JSON.parse(response.body, symbolize_names: true)
+
+            expect(response_body[:meta]).to eq(page: 1, per_page: 1, total_items: 1)
+          end
+        end
+
+        context 'given the user search for word vpn with match_at_least 2' do
+          it 'returns keywords contains the matched urls' do
+            user = Fabricate(:user)
+            result_urls = ['https://www.thetopvpn.com/vpn', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+            Fabricate(:keyword, result_urls: result_urls, user: user)
+            params = { filter: { word: 'vpn', match_at_least: '2' }, page: 1, per_page: 1 }
+
+            get api_v1_keywords_path, params: params, headers: create_token_header(user)
+            response_body = JSON.parse(response.body, symbolize_names: true)
+
+            expect(response_body[:data][0][:attributes][:matching_result_urls]).to eq(['https://www.thetopvpn.com/vpn'])
+          end
+
+          it 'returns metadata with page = 1, per_page = 1 and total_item = 1' do
+            user = Fabricate(:user)
+            result_urls = ['https://www.thetopvpn.com/vpn', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+            Fabricate(:keyword, result_urls: result_urls, user: user)
+            params = { filter: { word: 'vpn', match_at_least: '2' }, page: 1, per_page: 1 }
+
+            get api_v1_keywords_path, params: params, headers: create_token_header(user)
+            response_body = JSON.parse(response.body, symbolize_names: true)
+
+            expect(response_body[:meta]).to eq(page: 1, per_page: 1, total_items: 1)
+          end
+        end
+
+        context 'given there is no matched result' do
+          it 'returns empty' do
+            user = Fabricate(:user)
+            result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+            Fabricate(:keyword, result_urls: result_urls, user: user)
+            params = { filter: { word: 'vpn', match_at_least: '2' }, page: 1, per_page: 1 }
+
+            get api_v1_keywords_path, params: params, headers: create_token_header(user)
+            response_body = JSON.parse(response.body, symbolize_names: true)
+
+            expect(response_body[:data]).to be_empty
+          end
+
+          it 'returns metadata with page = 1, per_page = 1 and total_item = 0' do
+            user = Fabricate(:user)
+            result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+            Fabricate(:keyword, result_urls: result_urls, user: user)
+            params = { filter: { word: 'vpn', match_at_least: '2' }, page: 1, per_page: 1 }
+
+            get api_v1_keywords_path, params: params, headers: create_token_header(user)
+            response_body = JSON.parse(response.body, symbolize_names: true)
+
+            expect(response_body[:meta]).to eq(page: 1, per_page: 1, total_items: 0)
+          end
+        end
+
+        context 'given the user provided word parameter but left match_at_least nil' do
+          it 'returns all items' do
+            user = Fabricate(:user)
+            matched_result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+            unmatched_result_urls = ['https://www.google.com', 'https://www.bing.com']
+            Fabricate(:keyword, result_urls: matched_result_urls, user: user)
+            Fabricate(:keyword, result_urls: unmatched_result_urls, user: user)
+            params = { filter: { word: 'vpn' }, page: 1, per_page: 2 }
+
+            get api_v1_keywords_path, params: params, headers: create_token_header(user)
+            response_body = JSON.parse(response.body, symbolize_names: true)
+
+            expect(response_body[:data].count).to eq 2
+          end
+
+          it 'returns metadata with page = 1, per_page = 2 and total_item = 2' do
+            user = Fabricate(:user)
+            matched_result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+            unmatched_result_urls = ['https://www.google.com', 'https://www.bing.com']
+            Fabricate(:keyword, result_urls: matched_result_urls, user: user)
+            Fabricate(:keyword, result_urls: unmatched_result_urls, user: user)
+            params = { filter: { word: 'vpn' }, page: 1, per_page: 2 }
+
+            get api_v1_keywords_path, params: params, headers: create_token_header(user)
+            response_body = JSON.parse(response.body, symbolize_names: true)
+
+            expect(response_body[:meta]).to eq(page: 1, per_page: 2, total_items: 2)
+          end
+        end
+
+        context 'given the user provided match_at_least parameter but left word nil' do
+          it 'returns all items' do
+            user = Fabricate(:user)
+            matched_result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+            unmatched_result_urls = ['https://www.google.com', 'https://www.bing.com']
+            Fabricate(:keyword, result_urls: matched_result_urls, user: user)
+            Fabricate(:keyword, result_urls: unmatched_result_urls, user: user)
+            params = { filter: { match_at_least: '1' }, page: 1, per_page: 2 }
+
+            get api_v1_keywords_path, params: params, headers: create_token_header(user)
+            response_body = JSON.parse(response.body, symbolize_names: true)
+
+            expect(response_body[:data].count).to eq 2
+          end
+
+          it 'returns metadata with page = 1, per_page = 2 and total_item = 2' do
+            user = Fabricate(:user)
+            matched_result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+            unmatched_result_urls = ['https://www.google.com', 'https://www.bing.com']
+            Fabricate(:keyword, result_urls: matched_result_urls, user: user)
+            Fabricate(:keyword, result_urls: unmatched_result_urls, user: user)
+            params = { filter: { match_at_least: '1' }, page: 1, per_page: 2 }
+
+            get api_v1_keywords_path, params: params, headers: create_token_header(user)
+            response_body = JSON.parse(response.body, symbolize_names: true)
+
+            expect(response_body[:meta]).to eq(page: 1, per_page: 2, total_items: 2)
+          end
+        end
+
+        context 'given the user does not provide pagination parameters' do
+          it 'returns keywords contains the matched urls' do
+            user = Fabricate(:user)
+            result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+            Fabricate.times(2, :keyword, result_urls: result_urls, user: user)
+            params = { filter: { word: 'vpn', match_at_least: '1' } }
+
+            get api_v1_keywords_path, params: params, headers: create_token_header(user)
+            response_body = JSON.parse(response.body, symbolize_names: true)
+
+            expect(response_body[:data].count).to eq 2
+          end
+
+          it 'returns metadata with page = 1, per_page = 10 and total_item = 2' do
+            user = Fabricate(:user)
+            result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+            Fabricate.times(2, :keyword, result_urls: result_urls, user: user)
+            params = { filter: { word: 'vpn', match_at_least: '1' } }
+
+            get api_v1_keywords_path, params: params, headers: create_token_header(user)
+            response_body = JSON.parse(response.body, symbolize_names: true)
+
+            expect(response_body[:meta]).to eq(page: 1, per_page: 10, total_items: 2)
           end
         end
       end

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -134,6 +134,33 @@ RSpec.describe Api::V1::KeywordsController, type: :request do
               expect(response_body[:meta]).to eq(page: 1, per_page: 1, total_items: 0)
             end
           end
+
+          context 'given user search for word vpn in result_urls' do
+            it 'returns keywords contains the matched urls' do
+              user = Fabricate(:user)
+              result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+              Fabricate(:keyword, result_urls: result_urls, user: user)
+
+              params = { filter: { word: 'vpn', match_at_least: '1' }, page: 1, per_page: 1 }
+              get api_v1_keywords_path, params: params, headers: create_token_header(user)
+
+              response_body = JSON.parse(response.body, symbolize_names: true)
+              expect(response_body[:data][0][:attributes][:matching_result_urls]).to eq(['https://www.thetopvpn.com', 'https://www.nordvpn.com'])
+            end
+
+            it 'returns metadata with page = 1, per_page = 1 and total_item = 1' do
+              user = Fabricate(:user)
+              result_urls = ['https://www.thetopvpn.com', 'https://www.nordvpn.com', 'https://www.vnexpress.net']
+              Fabricate(:keyword, result_urls: result_urls, user: user)
+
+              params = { filter: { word: 'vpn', match_at_least: '1' }, page: 1, per_page: 1 }
+              get api_v1_keywords_path, params: params, headers: create_token_header(user)
+
+              response_body = JSON.parse(response.body, symbolize_names: true)
+
+              expect(response_body[:meta]).to eq(page: 1, per_page: 1, total_items: 1)
+            end
+          end
         end
 
         context 'given the user does not have any keyword' do


### PR DESCRIPTION
- close #24 
- close #25 

## What happened 👀

Add new functionality to the existing endpoint `GET api/v1/keywords` to allow a user filters keywords has `result_urls` containing a specific word and a number of matches. 

## Insight 📝

- Add a new function to filter the `result_urls` with  a specific word and a number of matches in `KeywordsQuery`
- Add new return parameter `matching_result_urls` in keyword_serializer`
- Write test.

## Proof Of Work 📹

<img width="1208" alt="Screenshot 2023-07-17 at 16 42 04" src="https://github.com/nimblehq/ic-rails-phong-bliss/assets/22606906/45dd6f4e-ef0b-475a-9b45-d480ab74da9c">

